### PR TITLE
Add Bank listing

### DIFF
--- a/lib/paystack.rb
+++ b/lib/paystack.rb
@@ -7,6 +7,7 @@ require 'paystack/objects/customers.rb'
 require 'paystack/objects/plans.rb'
 require 'paystack/objects/subscriptions.rb'
 require 'paystack/objects/transactions.rb'
+require 'paystack/objects/banks.rb'
 
 
 class Paystack
@@ -52,4 +53,3 @@ class Paystack
   end
 
 end
-

--- a/lib/paystack/modules/api.rb
+++ b/lib/paystack/modules/api.rb
@@ -5,4 +5,5 @@ module API
 	PLAN_PATH = "/plan"
 	CUSTOMER_PATH = "/customer"
 	SUBSCRIPTION_PATH = "/subscription"
+	BANK_PATH = "/bank"
 end

--- a/lib/paystack/objects/banks.rb
+++ b/lib/paystack/objects/banks.rb
@@ -1,0 +1,12 @@
+require 'paystack/objects/base.rb'
+
+class PaystackBanks < PaystackBaseObject
+	def list(page=1)
+		return PaystackBanks.list(@paystack, page)
+	end
+
+
+	def PaystackBanks.list(paystackObj, page=1)
+		initGetRequest(paystackObj, "#{API::BANK_PATH}?page=#{page}")
+	end
+end

--- a/spec/paystack_banks_spec.rb
+++ b/spec/paystack_banks_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'paystack/objects/banks.rb'
+require 'paystack.rb'
+
+public_test_key = "pk_test_ea7c71f838c766922873f1dd3cc529afe13da1c0"
+private_test_key = "sk_test_40e9340686e6187697f8309dbae57c002bb16dd0"
+
+describe PaystackBanks do
+
+	it "should return a list of banks" do
+		paystack = Paystack.new(public_test_key, private_test_key)
+		banks = PaystackBanks.new(paystack)
+		expect(banks.nil?).to eq false
+		list =  banks.list(1)
+		expect(list.nil?).to eq false
+	end
+
+end


### PR DESCRIPTION
This is required so subaccount creators will have the right bank name to send for each bank