### PR TITLE
Add Subaccount Object and Specs

### DIFF
--- a/lib/paystack/modules/api.rb
+++ b/lib/paystack/modules/api.rb
@@ -5,4 +5,5 @@ module API
 	PLAN_PATH = "/plan"
 	CUSTOMER_PATH = "/customer"
 	SUBSCRIPTION_PATH = "/subscription"
+	SUBACCOUNT_PATH = "/subaccount"
 end

--- a/lib/paystack/objects/subaccounts.rb
+++ b/lib/paystack/objects/subaccounts.rb
@@ -1,0 +1,37 @@
+require 'paystack/objects/base.rb'
+
+class PaystackSubaccounts < PaystackBaseObject
+	def create(data={})
+		return PaystackSubaccounts.create(@paystack, data)
+	end
+
+	def get(subaccount_id)
+		return PaystackSubaccounts.get(@paystack, subaccount_id)
+	end
+
+
+	def update(subaccount_id, data={})
+		return PaystackSubaccounts.update(@paystack, subaccount_id,  data)
+	end
+
+	def list(page=1)
+		return PaystackSubaccounts.list(@paystack, page)
+	end
+
+
+	def PaystackSubaccounts.create(paystackObj, data)
+		initPostRequest(paystackObj,"#{API::SUBACCOUNT_PATH}",  data)
+	end
+
+	def PaystackSubaccounts.update(paystackObj, subaccount_id, data)
+		initPutRequest(paystackObj,"#{API::SUBACCOUNT_PATH}/#{subaccount_id}",  data)
+	end
+
+	def PaystackSubaccounts.get(paystackObj, subaccount_id)
+		initGetRequest(paystackObj, "#{API::SUBACCOUNT_PATH}/#{subaccount_id}")
+	end
+
+	def PaystackSubaccounts.list(paystackObj, page=1)
+		initGetRequest(paystackObj, "#{API::SUBACCOUNT_PATH}?page=#{page}")
+	end
+end

--- a/spec/paystack_subaccounts_spec.rb
+++ b/spec/paystack_subaccounts_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'paystack/objects/subaccounts.rb'
+require 'paystack.rb'
+
+public_test_key = "pk_test_ea7c71f838c766922873f1dd3cc529afe13da1c0"
+private_test_key = "sk_test_40e9340686e6187697f8309dbae57c002bb16dd0"
+
+describe PaystackSubaccounts do
+	it "should return a valid subaccounts object" do
+		paystack = Paystack.new(public_test_key, private_test_key)
+		subaccounts = PaystackSubaccounts.new(paystack)
+		expect(subaccounts.nil?).to eq false
+	end
+
+	it "should return a list of subaccounts" do
+		paystack = Paystack.new(public_test_key, private_test_key)
+		subaccounts = PaystackSubaccounts.new(paystack)
+		expect(subaccounts.nil?).to eq false
+		list =  subaccounts.list(1)
+		expect(list.nil?).to eq false
+	end
+
+	it "should return a subaccount hashset/object" do
+		paystack = Paystack.new(public_test_key, private_test_key)
+		subaccounts = PaystackSubaccounts.new(paystack)
+		expect(subaccounts.nil?).to eq false
+		list =  subaccounts.list(1)
+		expect(list.nil?).to eq false
+		temp = list["data"][0]
+		hash=subaccounts.get(temp['id'])
+		expect(hash.nil?).to eq false
+		expect(hash['data']['id'].nil?).to eq false
+	end
+
+	it "should successfuly update a subaccount" do
+		paystack = Paystack.new(public_test_key, private_test_key)
+		subaccounts = PaystackSubaccounts.new(paystack)
+		expect(subaccounts.nil?).to eq false
+		list =  subaccounts.list(1)
+		expect(list.nil?).to eq false
+		temp = list["data"][0]
+		hash=subaccounts.update(temp['id'], :percentage_charge => 2.5)
+		expect(hash.nil?).to eq false
+		expect(hash['data']['id'].nil?).to eq false
+	end
+
+	it "should successfuly create a subaccount" do
+		paystack = Paystack.new(public_test_key, private_test_key)
+		subaccounts = PaystackSubaccounts.new(paystack)
+		expect(subaccounts.nil?).to eq false
+		temp = Random.new_seed.to_s
+		hash=subaccounts.create(:business_name => "#{temp[0..6]}-business", :settlement_bank => "Access Bank", :account_number => "01234567890", :percentage_charge => 2.5)
+		puts hash
+		expect(hash.nil?).to eq false
+		expect(hash['data']['id'].nil?).to eq false
+	end
+
+
+end

--- a/spec/paystack_subaccounts_spec.rb
+++ b/spec/paystack_subaccounts_spec.rb
@@ -39,7 +39,7 @@ describe PaystackSubaccounts do
 		list =  subaccounts.list(1)
 		expect(list.nil?).to eq false
 		temp = list["data"][0]
-		hash=subaccounts.update(temp['id'], :percentage_charge => 2.5)
+		hash=subaccounts.update(temp['id'], :percentage_charge => 2.5, :primary_contact_email => "xxxrr@gmail.com")
 		expect(hash.nil?).to eq false
 		expect(hash['data']['id'].nil?).to eq false
 	end


### PR DESCRIPTION
Split payments are available now on Paystack. https://developers.paystack.co/docs/split-payments-overview . The API calls for subaccount management are included in this PR