### PR TITLE
Add require 'paystack/objects/subaccounts.rb'

### DIFF
--- a/lib/paystack.rb
+++ b/lib/paystack.rb
@@ -12,6 +12,7 @@ require 'paystack/objects/balance.rb'
 require 'paystack/objects/settlements.rb'
 require 'paystack/objects/recipients.rb'
 require 'paystack/objects/transfers.rb'
+require 'paystack/objects/subaccounts.rb'
 
 
 class Paystack


### PR DESCRIPTION
Hi. Noticed this "require 'paystack/objects/subaccounts.rb'" was not included in the paystack.rb file.  I added it to my controller as a hack but I think sorting it out here could be a permanent solution. Please consider my contribution to your code and thank you for providing us rails developers with such a needed and useful gem. It made my life easier.