### PR TITLE
Feature/ta transfers verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,17 @@ The funds transfers feature enables you send money directly from your paystack b
 
 	transfer_code = "TRF_uniquecode"
 	transactions = PaystackTransfers.new(paystackObj)
-	result = transactions.get(transaction_code)
+	result = transactions.get(transfer_code)
+
+```
+
+### Verify a transfer
+
+```ruby
+
+	reference = "unique_reference"
+	transactions = PaystackTransfers.new(paystackObj)
+	result = transactions.verify(reference)
 
 ```
 

--- a/lib/paystack/objects/transfers.rb
+++ b/lib/paystack/objects/transfers.rb
@@ -1,7 +1,7 @@
 require 'paystack/objects/base.rb'
 
 class PaystackTransfers < PaystackBaseObject
-	
+
 	def initializeTransfer(args={})
 		return PaystackTransfers.initializeTransfer(@paystack, args)
 	end
@@ -14,6 +14,10 @@ class PaystackTransfers < PaystackBaseObject
 		return PaystackTransfers.get(@paystack, transfer_code)
 	end
 
+	def verify(reference)
+		return PaystackTransfers.verify(@paystack, reference)
+	end
+
 	def authorize(data={})
 		return PaystackTransfers.authorize(@paystack,data)
 	end
@@ -22,7 +26,7 @@ class PaystackTransfers < PaystackBaseObject
 		return PaystackTransfers.resendOtp(@paystack,data)
 	end
 
-	def  disableOtp 
+	def  disableOtp
 		return PaystackTransfers.disableOtp(@paystack)
 	end
 
@@ -30,7 +34,7 @@ class PaystackTransfers < PaystackBaseObject
 		return PaystackTransfers.confirmDisableOTP(@paystack,otp)
 	end
 
-	def  enableOtp 
+	def  enableOtp
 		return PaystackTransfers.enableOtp(@paystack)
 	end
 
@@ -40,12 +44,16 @@ class PaystackTransfers < PaystackBaseObject
 		initPostRequest(paystackObj,"#{API::TRANSFER_PATH}", args,true)
 	end
 
-	def PaystackTransfers.list(paystackObj, page=1)		
+	def PaystackTransfers.list(paystackObj, page=1)
 		initGetRequest(paystackObj, "#{API::TRANSFER_PATH}?page=#{page}")
 	end
 
 	def PaystackTransfers.get(paystackObj, transfer_code)
-	 	initGetRequest(paystackObj, "#{API::TRANSFER_PATH}/#{transfer_code}")
+		initGetRequest(paystackObj, "#{API::TRANSFER_PATH}/#{transfer_code}")
+	end
+
+	def PaystackTransfers.verify(paystackObj, reference)
+		initGetRequest(paystackObj, "#{API::TRANSFER_PATH}/verify/#{reference}")
 	end
 
 	def PaystackTransfers.authorize(paystackObj, data={})
@@ -70,6 +78,6 @@ class PaystackTransfers < PaystackBaseObject
 
 
 
- 
+
 
 end

--- a/spec/paystack_transfers_spec.rb
+++ b/spec/paystack_transfers_spec.rb
@@ -4,7 +4,7 @@ require 'paystack.rb'
 
 public_test_key = "pk_test_ea7c71f838c766922873f1dd3cc529afe13da1c0"
 private_test_key = "sk_test_40e9340686e6187697f8309dbae57c002bb16dd0"
-	
+
 describe PaystackTransfers do
 	it "should return a valid transfer object" do
 		paystack = Paystack.new(public_test_key, private_test_key)
@@ -49,8 +49,18 @@ describe PaystackTransfers do
 		hash = transfers.get(temp["transfer_code"])
 		expect(hash.nil?).to eq false
 		expect(hash['data']['transfer_code']).to eq temp["transfer_code"]
+  end
 
-
+	it "verify should return a valid transfer hashset" do
+		paystack = Paystack.new(public_test_key, private_test_key)
+		transfers = PaystackTransfers.new(paystack)
+		expect(transfers.nil?).to eq false
+		list =  transfers.list(1)
+		expect(list.nil?).to eq false
+		temp = list["data"][0]
+		hash = transfers.verify(temp["reference"])
+		expect(hash.nil?).to eq false
+		expect(hash['data']['verify']).to eq temp["verify"]
 	end
 
 	it "should resend OTP to authorize a transfer" do


### PR DESCRIPTION
Added the method/feature to use `PaystackTransfers.verify` to get transfer details via the reference. Apparently, `PaystackTransfers.get` no longer works with references and has been moved to it's own endpoint.